### PR TITLE
Improve admin reservation management

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,39 +1,327 @@
-import { signOut } from 'firebase/auth'
-import { auth } from '../firebase'
-import { useNavigate } from 'react-router-dom'
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase';
+import { useNavigate } from 'react-router-dom';
+import './styles/Admin.css';
+
+type User = {
+    id?: number;
+    name: string;
+    email: string;
+    dni: string;
+    password?: string;
+    role: { id: number } | null;
+};
+
+type Cabin = {
+    id?: number;
+    name: string;
+    description: string;
+    capacity: number;
+    available: boolean;
+};
+
+type Reservation = {
+    id?: number;
+    user: { id: number; name?: string } | null;
+    cabin: { id: number; name?: string } | null;
+    startDate: string;
+    endDate: string;
+    guests: number;
+    status: string;
+};
 
 function Admin() {
-    const navigate = useNavigate()
+    const navigate = useNavigate();
+    const token = localStorage.getItem('token');
+
+    const [tab, setTab] = useState<'users' | 'cabins' | 'reservations'>('users');
+    const [users, setUsers] = useState<User[]>([]);
+    const [cabins, setCabins] = useState<Cabin[]>([]);
+    const [reservations, setReservations] = useState<Reservation[]>([]);
+
+    const [userForm, setUserForm] = useState<User>({ name: '', email: '', dni: '', password: '', role: { id: 2 } });
+    const [editingUserId, setEditingUserId] = useState<number | null>(null);
+
+    const [cabinForm, setCabinForm] = useState<Cabin>({ name: '', description: '', capacity: 1, available: true });
+    const [editingCabinId, setEditingCabinId] = useState<number | null>(null);
+
+    const [resForm, setResForm] = useState<Reservation>({ user: null, cabin: null, startDate: '', endDate: '', guests: 1, status: 'PENDING' });
+    const [editingResId, setEditingResId] = useState<number | null>(null);
+
+    const headers = useMemo(() => {
+        const h: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) h.Authorization = `Bearer ${token}`;
+        return h;
+    }, [token]);
+
+    const fetchUsers = useCallback(async () => {
+        const res = await fetch('https://aike-api.onrender.com/users', { headers });
+        if (res.ok) setUsers(await res.json());
+    }, [headers]);
+
+    const fetchCabins = useCallback(async () => {
+        const res = await fetch('https://aike-api.onrender.com/cabins', { headers });
+        if (res.ok) setCabins(await res.json());
+    }, [headers]);
+
+    const fetchReservations = useCallback(async () => {
+        const res = await fetch('https://aike-api.onrender.com/reservations', { headers });
+        if (res.ok) setReservations(await res.json());
+    }, [headers]);
+
+    useEffect(() => {
+        if (tab === 'users') fetchUsers();
+        if (tab === 'cabins') fetchCabins();
+        if (tab === 'reservations') {
+            fetchReservations();
+            fetchUsers();
+            fetchCabins();
+        }
+    }, [tab, fetchUsers, fetchCabins, fetchReservations]);
 
     const handleLogout = async () => {
-        if (auth.currentUser) {
-            await signOut(auth)
-        }
-        localStorage.removeItem('token')
-        localStorage.removeItem('role')
-        navigate('/')
-    }
+        if (auth.currentUser) await signOut(auth);
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        navigate('/');
+    };
+
+    const handleUserSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const method = editingUserId ? 'PUT' : 'POST';
+        const url = editingUserId ? `https://aike-api.onrender.com/users/${editingUserId}` : 'https://aike-api.onrender.com/users';
+        await fetch(url, { method, headers, body: JSON.stringify(userForm) });
+        setUserForm({ name: '', email: '', dni: '', password: '', role: { id: 2 } });
+        setEditingUserId(null);
+        fetchUsers();
+    };
+
+    const handleCabinSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const method = editingCabinId ? 'PUT' : 'POST';
+        const url = editingCabinId ? `https://aike-api.onrender.com/cabins/${editingCabinId}` : 'https://aike-api.onrender.com/cabins';
+        await fetch(url, { method, headers, body: JSON.stringify(cabinForm) });
+        setCabinForm({ name: '', description: '', capacity: 1, available: true });
+        setEditingCabinId(null);
+        fetchCabins();
+    };
+
+    const handleResSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const method = editingResId ? 'PUT' : 'POST';
+        const url = editingResId
+            ? `https://aike-api.onrender.com/reservations/${editingResId}`
+            : 'https://aike-api.onrender.com/reservations';
+
+        const body = editingResId
+            ? {
+                  startDate: resForm.startDate,
+                  endDate: resForm.endDate,
+                  status: resForm.status,
+              }
+            : {
+                  user: { id: Number(resForm.user?.id) },
+                  cabin: { id: Number(resForm.cabin?.id) },
+                  startDate: resForm.startDate,
+                  endDate: resForm.endDate,
+                  guests: Number(resForm.guests),
+                  status: resForm.status,
+              };
+
+        await fetch(url, { method, headers, body: JSON.stringify(body) });
+        setResForm({ user: null, cabin: null, startDate: '', endDate: '', guests: 1, status: 'PENDING' });
+        setEditingResId(null);
+        fetchReservations();
+    };
+
+    const handleDelete = async (entity: string, id: number) => {
+        await fetch(`https://aike-api.onrender.com/${entity}/${id}`, { method: 'DELETE', headers });
+        if (entity === 'users') fetchUsers();
+        if (entity === 'cabins') fetchCabins();
+        if (entity === 'reservations') fetchReservations();
+    };
 
     return (
-        <div style={{ padding: '40px', textAlign: 'center' }}>
-            <h1>Admin Dashboard</h1>
-            <button
-                onClick={handleLogout}
-                style={{
-                    marginTop: '20px',
-                    padding: '10px 20px',
-                    fontSize: '16px',
-                    backgroundColor: '#8B5E3C',
-                    color: '#fff',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: 'pointer'
-                }}
-            >
-                Logout
-            </button>
+        <div className="admin-container">
+            <h1 className="text-2xl font-bold mb-4 text-center">Admin Dashboard</h1>
+            <div className="admin-nav mb-6 flex justify-center gap-4">
+                <button className={tab === 'users' ? 'active' : ''} onClick={() => setTab('users')}>Usuarios</button>
+                <button className={tab === 'cabins' ? 'active' : ''} onClick={() => setTab('cabins')}>Cabañas</button>
+                <button className={tab === 'reservations' ? 'active' : ''} onClick={() => setTab('reservations')}>Reservas</button>
+                <button onClick={handleLogout} className="logout">Logout</button>
+            </div>
+
+            {tab === 'users' && (
+                <div>
+                    <table className="admin-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Nombre</th>
+                                <th>Email</th>
+                                <th>DNI</th>
+                                <th>Rol</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {users.map((u) => (
+                                <tr key={u.id}>
+                                    <td>{u.id}</td>
+                                    <td>{u.name}</td>
+                                    <td>{u.email}</td>
+                                    <td>{u.dni}</td>
+                                    <td>{u.role?.id === 1 ? 'ADMIN' : 'CLIENT'}</td>
+                                    <td className="actions">
+                                        <button onClick={() => { setUserForm({ ...u, password: '' }); setEditingUserId(u.id || null); }}>Editar</button>
+                                        <button onClick={() => handleDelete('users', u.id!)}>Borrar</button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    <form onSubmit={handleUserSubmit} className="admin-form">
+                        <input placeholder="Nombre" value={userForm.name} onChange={e => setUserForm({ ...userForm, name: e.target.value })} required />
+                        <input placeholder="Email" value={userForm.email} onChange={e => setUserForm({ ...userForm, email: e.target.value })} required />
+                        <input placeholder="DNI" value={userForm.dni} onChange={e => setUserForm({ ...userForm, dni: e.target.value })} required />
+                        <input placeholder="Contraseña" type="password" value={userForm.password || ''} onChange={e => setUserForm({ ...userForm, password: e.target.value })} required={!editingUserId} />
+                        <select value={userForm.role?.id} onChange={e => setUserForm({ ...userForm, role: { id: Number(e.target.value) } })}>
+                            <option value={1}>ADMIN</option>
+                            <option value={2}>CLIENT</option>
+                        </select>
+                        <button type="submit">{editingUserId ? 'Actualizar' : 'Crear'}</button>
+                    </form>
+                </div>
+            )}
+
+            {tab === 'cabins' && (
+                <div>
+                    <table className="admin-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Nombre</th>
+                                <th>Descripción</th>
+                                <th>Capacidad</th>
+                                <th>Disponible</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {cabins.map((c) => (
+                                <tr key={c.id}>
+                                    <td>{c.id}</td>
+                                    <td>{c.name}</td>
+                                    <td>{c.description}</td>
+                                    <td>{c.capacity}</td>
+                                    <td>{c.available ? 'Sí' : 'No'}</td>
+                                    <td className="actions">
+                                        <button onClick={() => { setCabinForm({ ...c }); setEditingCabinId(c.id || null); }}>Editar</button>
+                                        <button onClick={() => handleDelete('cabins', c.id!)}>Borrar</button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    <form onSubmit={handleCabinSubmit} className="admin-form">
+                        <input placeholder="Nombre" value={cabinForm.name} onChange={e => setCabinForm({ ...cabinForm, name: e.target.value })} required />
+                        <input placeholder="Descripción" value={cabinForm.description} onChange={e => setCabinForm({ ...cabinForm, description: e.target.value })} required />
+                        <input type="number" placeholder="Capacidad" value={cabinForm.capacity} onChange={e => setCabinForm({ ...cabinForm, capacity: Number(e.target.value) })} required />
+                        <select value={cabinForm.available ? '1' : '0'} onChange={e => setCabinForm({ ...cabinForm, available: e.target.value === '1' })}>
+                            <option value="1">Disponible</option>
+                            <option value="0">No disponible</option>
+                        </select>
+                        <button type="submit">{editingCabinId ? 'Actualizar' : 'Crear'}</button>
+                    </form>
+                </div>
+            )}
+
+            {tab === 'reservations' && (
+                <div>
+                    <table className="admin-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Usuario</th>
+                                <th>Cabaña</th>
+                                <th>Desde</th>
+                                <th>Hasta</th>
+                                <th>Huéspedes</th>
+                                <th>Estado</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {reservations.map((r) => (
+                                <tr key={r.id}>
+                                    <td>{r.id}</td>
+                                    <td>{r.user?.name}</td>
+                                    <td>{r.cabin?.name}</td>
+                                    <td>{r.startDate}</td>
+                                    <td>{r.endDate}</td>
+                                    <td>{r.guests}</td>
+                                    <td>{r.status}</td>
+                                    <td className="actions">
+                                        <button
+                                            onClick={() => {
+                                                setResForm({ ...r });
+                                                setEditingResId(r.id || null);
+                                            }}
+                                        >
+                                            Editar
+                                        </button>
+                                        <button onClick={() => handleDelete('reservations', r.id!)}>Borrar</button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    <form onSubmit={handleResSubmit} className="admin-form">
+                        <select
+                            value={resForm.user?.id ?? ''}
+                            onChange={e => setResForm({ ...resForm, user: { id: Number(e.target.value) } })}
+                            disabled={!!editingResId}
+                            required
+                        >
+                            <option value="" disabled>
+                                Seleccionar usuario
+                            </option>
+                            {users.map(u => (
+                                <option key={u.id} value={u.id}>
+                                    {u.name}
+                                </option>
+                            ))}
+                        </select>
+                        <select
+                            value={resForm.cabin?.id ?? ''}
+                            onChange={e => setResForm({ ...resForm, cabin: { id: Number(e.target.value) } })}
+                            disabled={!!editingResId}
+                            required
+                        >
+                            <option value="" disabled>
+                                Seleccionar cabaña
+                            </option>
+                            {cabins.map(c => (
+                                <option key={c.id} value={c.id}>
+                                    {c.name}
+                                </option>
+                            ))}
+                        </select>
+                        <input type="date" value={resForm.startDate} onChange={e => setResForm({ ...resForm, startDate: e.target.value })} required />
+                        <input type="date" value={resForm.endDate} onChange={e => setResForm({ ...resForm, endDate: e.target.value })} required />
+                        <input type="number" value={resForm.guests} onChange={e => setResForm({ ...resForm, guests: Number(e.target.value) })} disabled={!!editingResId} required />
+                        <select value={resForm.status} onChange={e => setResForm({ ...resForm, status: e.target.value })}>
+                            <option value="PENDING">PENDING</option>
+                            <option value="CONFIRMED">CONFIRMED</option>
+                            <option value="CANCELLED">CANCELLED</option>
+                        </select>
+                        <button type="submit">{editingResId ? 'Actualizar' : 'Crear'}</button>
+                    </form>
+                </div>
+            )}
         </div>
-    )
+    );
 }
 
-export default Admin
+export default Admin;

--- a/src/pages/Reservation.tsx
+++ b/src/pages/Reservation.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
 import './styles/Reservation.css';
 
 function decodeToken(token: string) {
@@ -17,7 +16,6 @@ function Reservation() {
   const navigate = useNavigate();
   const token = localStorage.getItem('token');
   const role = localStorage.getItem('role');
-  const { user } = useAuth();
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [guests, setGuests] = useState('1');

--- a/src/pages/styles/Admin.css
+++ b/src/pages/styles/Admin.css
@@ -1,0 +1,75 @@
+.admin-container {
+    max-width: 1100px;
+    margin: 80px auto;
+    padding: 20px;
+    background-color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    font-family: 'Montserrat', sans-serif;
+}
+
+.admin-nav button {
+    padding: 8px 16px;
+    background-color: #0f766e;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.admin-nav button.active {
+    background-color: #134e4a;
+}
+
+.admin-nav .logout {
+    background-color: #8B5E3C;
+    margin-left: auto;
+}
+
+.admin-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+
+.admin-table th, .admin-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+.admin-table th {
+    background-color: #f0fdfc;
+}
+
+.actions button {
+    margin-right: 8px;
+    padding: 4px 8px;
+    background-color: #0f766e;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.admin-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.admin-form input,
+.admin-form select {
+    padding: 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.admin-form button {
+    padding: 8px 16px;
+    background-color: #0f766e;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- refine Reservation types in Admin dashboard
- fetch users and cabins for reservation tab
- display names instead of IDs for reservations
- allow selecting users and cabins from dropdowns
- disable changing user and cabin when editing

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861ed8c8f50832ea92ceddd87ec106c