### PR TITLE
Fix navbar state updates and remove admin home button

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,28 +1,51 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { signOut } from 'firebase/auth';
 import { auth } from '../firebase';
 
 function Navbar() {
     const { user } = useAuth();
-    const token = localStorage.getItem('token');
-    let role = localStorage.getItem('role');
-    if (!role && token) {
-        try {
-            role = JSON.parse(atob(token.split('.')[1])).r;
-        } catch {
-            role = null;
+    const location = useLocation();
+    const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
+    const [role, setRole] = useState<string | null>(() => {
+        const storedRole = localStorage.getItem('role');
+        if (storedRole) return storedRole;
+        if (token) {
+            try {
+                return JSON.parse(atob(token.split('.')[1])).r;
+            } catch {
+                return null;
+            }
         }
-    }
+        return null;
+    });
     const isAdmin = role === 'ADMIN';
     const [menuOpen, setMenuOpen] = useState(false);
+
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const t = localStorage.getItem('token');
+        let r = localStorage.getItem('role');
+        if (!r && t) {
+            try {
+                r = JSON.parse(atob(t.split('.')[1])).r;
+            } catch {
+                r = null;
+            }
+        }
+        setToken(t);
+        setRole(r);
+    }, [location]);
 
     const handleLogout = async () => {
         if (user) await signOut(auth);
         localStorage.removeItem('token');
         localStorage.removeItem('role');
-        window.location.reload();
+        setToken(null);
+        setRole(null);
+        navigate('/');
     };
 
     return (
@@ -35,7 +58,7 @@ function Navbar() {
                     <h1 className="text-2xl font-bold text-teal-700">Aike</h1>
                 </div>
                 <div className="hidden md:flex space-x-8">
-                    <a href="#inicio" className="text-gray-700 hover:text-teal-700 font-medium">Inicio</a>
+                    <Link to="/" className="text-gray-700 hover:text-teal-700 font-medium">Inicio</Link>
                     <a href="#nosotros" className="text-gray-700 hover:text-teal-700 font-medium">Nosotros</a>
                     <a href="#cabanas" className="text-gray-700 hover:text-teal-700 font-medium">Cabañas</a>
                     <a href="#ubicacion" className="text-gray-700 hover:text-teal-700 font-medium">Ubicación</a>
@@ -63,7 +86,7 @@ function Navbar() {
             </div>
             {menuOpen && (
                 <div className="md:hidden bg-white pb-4 px-4">
-                    <a href="#inicio" className="block py-2 text-gray-700 hover:text-teal-700 font-medium">Inicio</a>
+                    <Link to="/" className="block py-2 text-gray-700 hover:text-teal-700 font-medium">Inicio</Link>
                     <a href="#nosotros" className="block py-2 text-gray-700 hover:text-teal-700 font-medium">Nosotros</a>
                     <a href="#cabanas" className="block py-2 text-gray-700 hover:text-teal-700 font-medium">Cabañas</a>
                     <a href="#ubicacion" className="block py-2 text-gray-700 hover:text-teal-700 font-medium">Ubicación</a>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -151,9 +151,6 @@ async function validateImage(url: string) {
     navigate("/");
   };
 
-  const handleHome = () => {
-    navigate("/");
-  };
 
   const handleUserSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -300,9 +297,6 @@ async function validateImage(url: string) {
           onClick={() => setTab("products")}
         >
           Productos
-        </button>
-        <button onClick={handleHome} className="home">
-          Inicio
         </button>
         <button onClick={handleLogout} className="logout">
           Logout


### PR DESCRIPTION
## Summary
- keep track of auth token/role in Navbar state
- update token/role when route changes
- make navbar logout update state and redirect
- use router `Link` for "Inicio" links
- remove unused "Inicio" button from admin panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877c8b74d1c832e956aa52ae61c9d29