### PR TITLE
Remove booking form and enlarge hero text

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,9 +30,6 @@ function Home() {
     const [cabins, setCabins] = useState<Cabin[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
-    const [startDate, setStartDate] = useState('')
-    const [endDate, setEndDate] = useState('')
-    const [guests, setGuests] = useState('1')
     const navigate = useNavigate()
 
     useEffect(() => {
@@ -129,83 +126,14 @@ function Home() {
         navigate(`/reservation/${id}`)
     }
 
-    const handleSearch = async () => {
-        if (!startDate || !endDate) {
-            alert('Por favor selecciona las fechas de tu estadía')
-            return
-        }
-        setLoading(true)
-        try {
-            const params = new URLSearchParams({
-                startDate,
-                endDate,
-                guests,
-            })
-            const res = await fetch(`${API_URL}/cabins/available?${params.toString()}`)
-            if (!res.ok) throw new Error('Error al buscar disponibilidad')
-            const data = await res.json()
-            setCabins(data)
-            setError(null)
-        } catch (err) {
-            const message = err instanceof Error ? err.message : 'Error al buscar disponibilidad'
-            setError(message)
-            setCabins([])
-        } finally {
-            setLoading(false)
-        }
-    }
-
     return (
         <>
             <section id="inicio" className="hero h-screen flex items-center justify-center pt-16">
-                <div className="container mx-auto px-4 text-center">
-                    <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">Descubre la magia de la Patagonia</h1>
-                    <p className="text-xl md:text-2xl text-white mb-10 max-w-3xl mx-auto">Cabañas Aike, tu refugio perfecto en el corazón del sur argentino</p>
-                    <div className="date-picker p-6 rounded-lg max-w-3xl mx-auto">
-                        <h3 className="text-xl font-semibold text-gray-800 mb-4">Reserva tu estadía</h3>
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                             <div>
-                                 <label className="block text-gray-700 text-sm font-medium mb-2">Fecha de llegada</label>
-                                 <input
-                                     type="date"
-                                     value={startDate}
-                                     onChange={e => setStartDate(e.target.value)}
-                                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500"
-                                 />
-                             </div>
-                             <div>
-                                 <label className="block text-gray-700 text-sm font-medium mb-2">Fecha de salida</label>
-                                 <input
-                                     type="date"
-                                     value={endDate}
-                                     onChange={e => setEndDate(e.target.value)}
-                                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500"
-                                 />
-                             </div>
-                             <div>
-                                 <label className="block text-gray-700 text-sm font-medium mb-2">Huéspedes</label>
-                                 <select
-                                     value={guests}
-                                     onChange={e => setGuests(e.target.value)}
-                                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500"
-                                 >
-                                     <option value="1">1 persona</option>
-                                     <option value="2">2 personas</option>
-                                     <option value="3">3 personas</option>
-                                     <option value="4">4 personas</option>
-                                     <option value="5">5+ personas</option>
-                                 </select>
-                             </div>
-                          </div>
-                          <button
-                              className="bg-teal-600 hover:bg-teal-700 text-white font-medium py-2 px-6 rounded-md transition duration-300 w-full md:w-auto"
-                              onClick={handleSearch}
-                          >
-                              Buscar disponibilidad
-                          </button>
-                      </div>
-                  </div>
-              </section>
+                <div className="container mx-auto px-4 text-center space-y-8">
+                    <h1 className="text-5xl md:text-7xl font-bold text-white">Descubre la magia de la Patagonia</h1>
+                    <p className="text-2xl md:text-3xl text-white max-w-4xl mx-auto">Cabañas Aike, tu refugio perfecto en el corazón del sur argentino</p>
+                </div>
+            </section>
 
             <section id="nosotros" className="py-16 bg-white">
                 <div className="container mx-auto px-4">

--- a/src/pages/styles/Home.css
+++ b/src/pages/styles/Home.css
@@ -14,11 +14,6 @@ body {
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
-.date-picker {
-    background-color: rgba(255, 255, 255, 0.9);
-    backdrop-filter: blur(5px);
-}
-
 .about-image {
     background-image: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400' viewBox='0 0 600 400'%3E%3Crect width='600' height='400' fill='%23184E77'/%3E%3Cpath d='M0 300 L100 250 L200 280 L300 220 L400 260 L500 200 L600 240 L600 400 L0 400 Z' fill='%231A759F'/%3E%3Cpath d='M0 320 L100 310 L200 330 L300 300 L400 340 L500 310 L600 330 L600 400 L0 400 Z' fill='%2334A0A4'/%3E%3Cpath d='M0 350 L100 340 L200 360 L300 340 L400 370 L500 350 L600 360 L600 400 L0 400 Z' fill='%2376C893'/%3E%3C/svg%3E");
     background-size: cover;


### PR DESCRIPTION
## Summary
- Remove date picker booking form and search logic from the home page hero section
- Increase hero heading size and center introductory text to fill space
- Drop unused date-picker styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ec1194cf8832ebc01ac3867bb21a3