### PR TITLE
fix: use email for google login

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -59,7 +59,7 @@ function Home() {
             }
 
             const idToken = await result.user.getIdToken()
-            const loginRes = await fetch(`${API_URL}/auth/login-google`, {
+            const loginRes = await fetch(`${API_URL}/auth/login-google-web`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ idToken })

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -47,7 +47,7 @@ function Login() {
             }
 
             const idToken = await result.user.getIdToken()
-            const loginRes = await fetch(`${API_URL}/auth/login-google`, {
+            const loginRes = await fetch(`${API_URL}/auth/login-google-web`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ idToken })

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -52,8 +52,8 @@ function Login() {
                 body: JSON.stringify({ user: email, password: 'from-google' })
             })
 
-            if (!loginRes.ok) {
-                await fetch(`${API_URL}/users`, {
+            if (loginRes.status === 401) {
+                const createRes = await fetch(`${API_URL}/users`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -64,6 +64,13 @@ function Login() {
                         role: { id: 2 }
                     })
                 })
+
+                if (!createRes.ok) {
+                    await signOut(auth)
+                    alert('Error al iniciar sesión')
+                    return
+                }
+
                 loginRes = await fetch(`${API_URL}/auth/login`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -46,37 +46,12 @@ function Login() {
                 return
             }
 
-            let loginRes = await fetch(`${API_URL}/auth/login`, {
+            const idToken = await result.user.getIdToken()
+            const loginRes = await fetch(`${API_URL}/auth/login-google`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ user: email, password: 'from-google' })
+                body: JSON.stringify({ idToken })
             })
-
-            if (loginRes.status === 401) {
-                const createRes = await fetch(`${API_URL}/users`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        name: result.user.displayName || email,
-                        email,
-                        dni: '',
-                        password: 'from-google',
-                        role: { id: 2 }
-                    })
-                })
-
-                if (!createRes.ok) {
-                    await signOut(auth)
-                    alert('Error al iniciar sesión')
-                    return
-                }
-
-                loginRes = await fetch(`${API_URL}/auth/login`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ user: email, password: 'from-google' })
-                })
-            }
 
             if (loginRes.ok) {
                 const data = await loginRes.json()

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -44,7 +44,7 @@ function Register() {
             }
 
             const idToken = await result.user.getIdToken()
-            const loginRes = await fetch(`${API_URL}/auth/login-google`, {
+            const loginRes = await fetch(`${API_URL}/auth/login-google-web`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ idToken })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "unsafe-none" }
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,17 @@ export default defineConfig({
   },
   server: {
     headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups'
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+      'Cross-Origin-Embedder-Policy': 'unsafe-none'
     },
     proxy: {
       '/cabins': process.env.VITE_API_BASE_URL as string
+    }
+  },
+  preview: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+      'Cross-Origin-Embedder-Policy': 'unsafe-none'
     }
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     }
   },
   server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups'
+    },
     proxy: {
       '/cabins': process.env.VITE_API_BASE_URL as string
     }


### PR DESCRIPTION
## Summary
- use Google account email to authenticate against backend
- alert when no email is available or backend login fails
- sign out from Firebase if backend login doesn't provide token

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ecb4f6910832ebb2c2fe3d5ec1973