### PR TITLE
Sanitize bearer token before storage

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -44,7 +44,8 @@ type Product = {
 
 function Admin() {
   const navigate = useNavigate();
-  const token = localStorage.getItem("token");
+  const rawToken = localStorage.getItem("token");
+  const token = rawToken?.startsWith("Bearer ") ? rawToken.slice(7) : rawToken;
 
   const [tab, setTab] = useState<
     "users" | "cabins" | "reservations" | "products"

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -40,6 +40,7 @@ type Product = {
   price: number;
   imageUrl: string;
   category: string;
+  stock: number;
 };
 
 function Admin() {
@@ -89,7 +90,8 @@ function Admin() {
     description: "",
     price: 0,
     imageUrl: "",
-    category: ""
+    category: "",
+    stock: 0
   });
   const [productImgError, setProductImgError] = useState<string | null>(null);
   const [editingProductId, setEditingProductId] = useState<number | null>(null);
@@ -254,7 +256,8 @@ async function validateImage(url: string) {
       description: "",
       price: 0,
       imageUrl: "",
-      category: ""
+      category: "",
+      stock: 0
     });
     setEditingProductId(null);
     fetchProducts();
@@ -622,6 +625,7 @@ async function validateImage(url: string) {
                 <th>Precio</th>
                 <th>Imagen</th>
                 <th>Categoría</th>
+                <th>Stock</th>
                 <th>Acciones</th>
               </tr>
             </thead>
@@ -644,6 +648,7 @@ async function validateImage(url: string) {
                     )}
                   </td>
                   <td>{p.category}</td>
+                  <td>{p.stock}</td>
                   <td className="actions">
                     <button
                       onClick={() => {
@@ -686,6 +691,18 @@ async function validateImage(url: string) {
                 setProductForm({
                   ...productForm,
                   price: Number(e.target.value)
+                })
+              }
+              required
+            />
+            <input
+              type="number"
+              placeholder="Stock"
+              value={productForm.stock}
+              onChange={e =>
+                setProductForm({
+                  ...productForm,
+                  stock: Number(e.target.value)
                 })
               }
               required

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -37,10 +37,12 @@ function Login() {
                 return
             }
             const data = await loginRes.json()
-            localStorage.setItem('token', data.token)
+            const rawToken: string = data.token
+            const token = rawToken.startsWith('Bearer ') ? rawToken.slice(7) : rawToken
+            localStorage.setItem('token', token)
             let role = 'CLIENT'
             try {
-                const payload = JSON.parse(atob(data.token.split('.')[1]))
+                const payload = JSON.parse(atob(token.split('.')[1]))
                 role = payload.r
                 localStorage.setItem('role', role)
             } catch {
@@ -69,10 +71,12 @@ function Login() {
             })
             if (!res.ok) throw new Error('Error')
             const data = await res.json()
-            localStorage.setItem('token', data.token)
+            const rawToken: string = data.token
+            const token = rawToken.startsWith('Bearer ') ? rawToken.slice(7) : rawToken
+            localStorage.setItem('token', token)
             let role = 'CLIENT'
             try {
-                const payload = JSON.parse(atob(data.token.split('.')[1]))
+                const payload = JSON.parse(atob(token.split('.')[1]))
                 role = payload.r
                 localStorage.setItem('role', role)
             } catch {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -39,10 +39,12 @@ function Register() {
                 return
             }
             const data = await loginRes.json()
-            localStorage.setItem('token', data.token)
+            const rawToken: string = data.token
+            const token = rawToken.startsWith('Bearer ') ? rawToken.slice(7) : rawToken
+            localStorage.setItem('token', token)
             let role = 'CLIENT'
             try {
-                const payload = JSON.parse(atob(data.token.split('.')[1]))
+                const payload = JSON.parse(atob(token.split('.')[1]))
                 role = payload.r
                 localStorage.setItem('role', role)
             } catch {


### PR DESCRIPTION
## Summary
- strip `Bearer` prefix from tokens returned by login endpoints before saving

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68920d3ad170832eb7a409d9fcd07430