### PR TITLE
fix: move google types to top-level

### DIFF
--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -2,6 +2,27 @@ import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import './styles/Login.css'
 
+interface GoogleAccounts {
+    accounts: {
+        id: {
+            initialize: (config: {
+                client_id: string
+                callback: (response: { credential: string }) => void
+            }) => void
+            renderButton: (
+                element: HTMLElement | null,
+                options: { theme: string; size: string }
+            ) => void
+        }
+    }
+}
+
+declare global {
+    interface Window {
+        google: GoogleAccounts | undefined
+    }
+}
+
 const API_URL = import.meta.env.VITE_API_BASE_URL
 
 function Register() {
@@ -10,21 +31,6 @@ function Register() {
     const [username, setUsername] = useState('')
     const [dni, setDni] = useState('')
     const navigate = useNavigate()
-
-    interface GoogleAccounts {
-        accounts: {
-            id: {
-                initialize: (config: { client_id: string; callback: (response: { credential: string }) => void }) => void
-                renderButton: (element: HTMLElement | null, options: { theme: string; size: string }) => void
-            }
-        }
-    }
-
-    declare global {
-        interface Window {
-            google: GoogleAccounts | undefined
-        }
-    }
 
     useEffect(() => {
         const handleCredentialResponse = async (response: { credential: string }) => {


### PR DESCRIPTION
## Summary
- fix Register page TypeScript error by moving Google type declarations to the module scope

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892217f3778832e9e5c14d59d61f90b