### PR TITLE
Handle already reserved cabin with user-friendly message

### DIFF
--- a/src/pages/Reservation.tsx
+++ b/src/pages/Reservation.tsx
@@ -61,6 +61,10 @@ function Reservation() {
       });
       if (!res.ok) {
         const text = await res.text();
+        if (res.status === 409 || text.toLowerCase().includes('reservada')) {
+          setError('Cabaña no disponible. Ya se encuentra reservada');
+          return;
+        }
         throw new Error(text || 'Error');
       }
       const reservation = await res.json();


### PR DESCRIPTION
## Summary
- Show friendly error when reservation endpoint returns conflict indicating cabin is already booked

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928ebb6fe4832e8329efa08d41d2e2