### PR TITLE
Add confirmation dialog for admin deletions

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -95,6 +95,9 @@ function Admin() {
   });
   const [productImgError, setProductImgError] = useState<string | null>(null);
   const [editingProductId, setEditingProductId] = useState<number | null>(null);
+  const [deleteInfo, setDeleteInfo] = useState<{ entity: string; id: number } | null>(
+    null
+  );
 
 const headers = useMemo(() => {
   const h: Record<string, string> = { "Content-Type": "application/json" };
@@ -258,13 +261,26 @@ async function validateImage(url: string) {
     fetchProducts();
   };
 
-  const handleDelete = async (entity: string, id: number) => {
+  const deleteItem = async (entity: string, id: number) => {
     await fetch(`${API_URL}/${entity}/${id}`, { method: "DELETE", headers });
     if (entity === "users") fetchUsers();
     if (entity === "cabins") fetchCabins();
     if (entity === "reservations") fetchReservations();
     if (entity === "products") fetchProducts();
   };
+
+  const handleDelete = (entity: string, id: number) => {
+    setDeleteInfo({ entity, id });
+  };
+
+  const confirmDelete = async () => {
+    if (deleteInfo) {
+      await deleteItem(deleteInfo.entity, deleteInfo.id);
+      setDeleteInfo(null);
+    }
+  };
+
+  const cancelDelete = () => setDeleteInfo(null);
 
   return (
     <div className="admin-container">
@@ -722,6 +738,22 @@ async function validateImage(url: string) {
               {editingProductId ? "Actualizar" : "Crear"}
             </button>
           </form>
+        </div>
+      )}
+
+      {deleteInfo && (
+        <div className="confirm-overlay">
+          <div className="confirm-dialog">
+            <p>¿Seguro que deseas eliminar este elemento?</p>
+            <div className="buttons">
+              <button className="confirm" onClick={confirmDelete}>
+                Eliminar
+              </button>
+              <button className="cancel" onClick={cancelDelete}>
+                Cancelar
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/pages/styles/Admin.css
+++ b/src/pages/styles/Admin.css
@@ -82,3 +82,50 @@
     color: #dc2626;
     width: 100%;
 }
+
+.confirm-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.confirm-dialog {
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    text-align: center;
+    font-family: 'Montserrat', sans-serif;
+}
+
+.confirm-dialog .buttons {
+    margin-top: 20px;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+.confirm-dialog .confirm {
+    background-color: #0f766e;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 16px;
+    cursor: pointer;
+}
+
+.confirm-dialog .cancel {
+    background-color: #dc2626;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 16px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- prompt admin for confirmation before deleting users, cabins, reservations or products
- style confirmation dialog to match existing admin theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68950d771628832e9a948cf9c0cd7824